### PR TITLE
Fix for ie11 strict mode

### DIFF
--- a/source/guest/index.js
+++ b/source/guest/index.js
@@ -21,7 +21,7 @@ module.exports = function storageGuest(source, parent) {
     iframe.src = source;
     iframe.width = 0;
     iframe.height = 0;
-    iframe.style = 'display: none;';
+    iframe.style.display = 'none;';
     iframe.onload = () => {
         isLoaded = true;
     };
@@ -48,7 +48,7 @@ module.exports = function storageGuest(source, parent) {
         }
 
         if (response.connectError) {
-            Object.keys(callbacks).forEach(key => callbacks[key](response.error));
+            Object.keys(callbacks).forEach((key) => callbacks[key](response.error));
             callbacks = {};
             return;
         }


### PR DESCRIPTION
This is a fix for the following error that I'm seeing from my react app (using create-react-app) in IE11

```
SCRIPT5045: Assignment to read-only properties is not allowed in strict mode
```