### PR TITLE
Fix simultaneous requests having the same IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@midorina/cross-domain-storage",
+    "name": "cross-domain-storage",
     "version": "2.0.7",
     "description": "Cross domain local storage",
     "main": "./",
@@ -26,14 +26,14 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Midorina/cross-domain-storage.git"
+        "url": "git+https://github.com/MatthewLarner/cross-domain-storage.git"
     },
     "author": "Matt Larner <matt.larner.dev@gmail.com>",
     "license": "ISC",
     "bugs": {
-        "url": "https://github.com/Midorina/cross-domain-storage/issues"
+        "url": "https://github.com/MatthewLarner/cross-domain-storage/issues"
     },
-    "homepage": "https://github.com/Midorina/cross-domain-storage#readme",
+    "homepage": "https://github.com/MatthewLarner/cross-domain-storage#readme",
     "dependencies": {},
     "devDependencies": {
         "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "cross-domain-storage",
+    "name": "@midorina/cross-domain-storage",
     "version": "2.0.7",
     "description": "Cross domain local storage",
     "main": "./",
@@ -26,14 +26,14 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/MatthewLarner/cross-domain-storage.git"
+        "url": "git+https://github.com/Midorina/cross-domain-storage.git"
     },
     "author": "Matt Larner <matt.larner.dev@gmail.com>",
     "license": "ISC",
     "bugs": {
-        "url": "https://github.com/MatthewLarner/cross-domain-storage/issues"
+        "url": "https://github.com/Midorina/cross-domain-storage/issues"
     },
-    "homepage": "https://github.com/MatthewLarner/cross-domain-storage#readme",
+    "homepage": "https://github.com/Midorina/cross-domain-storage#readme",
     "dependencies": {},
     "devDependencies": {
         "babel-cli": "^6.26.0",

--- a/source/guest/index.js
+++ b/source/guest/index.js
@@ -3,7 +3,7 @@ const getId = require('../getId');
 const prefix = 'sessionAccessId-';
 
 function createId() {
-    return prefix + Date.now();
+    return prefix + (Math.random() * Date.now());
 }
 
 module.exports = function storageGuest(source, parent) {


### PR DESCRIPTION
When requests are called almost at the same time, they have the same ID and the callbacks get mixed. This PR increases the uniqueness of IDs, which fixes the issue.